### PR TITLE
Add support for app factory pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ The package will do one of two things:
 You can install the request-id-flask package using pip:
 
 ```shell
-pip install flask-ext-request-id
+pip install request-id-flask
 ```
 
-However, recommended to add it to the `requirements.txt` file instead.
+However, recommended to add it to the `requirements.txt` file instead, and install using: `pip install -r requirements.txt`
+```
+request-id-flask~=0.0.3
+```
 
 ## Access the request_id
 
 The `REQUEST_ID` is stored in the request `environ` dictionary and may be accessed from anywhere this is available in Flask.
+Version `0.0.3` adds support for the [app factory pattern](https://flask.palletsprojects.com/en/2.3.x/patterns/appfactories/).
 
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='request-id-flask',
-    version='0.0.2',
+    version='0.0.3',
     description='Receive and return the value of HTTP X-Request-ID header.',
     long_description=read_me,
     long_description_content_type='text/markdown',
@@ -25,10 +25,18 @@ setup(
     python_requires='>=3.6',
     classifiers=[
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
         'License :: OSI Approved :: MIT License',
     ],
     install_requires=[
         'flask',
+        'uuid',
     ],
 )

--- a/src/request_id/middleware.py
+++ b/src/request_id/middleware.py
@@ -11,11 +11,6 @@ class RequestId(object):
         # Load configuration
         if app is not None:
             self.init_app(app)
-        # Define header names
-        self._header = app.config.get('REQUEST_ID_HEADER_NAME')
-        # Set wsgi
-        self.app = app.wsgi_app
-        app.wsgi_app = self
 
     def init_app(self, app):
         # Set configuration
@@ -23,6 +18,11 @@ class RequestId(object):
             'REQUEST_ID_HEADER_NAME',
             'X-Request-ID'
         )
+        # Define header names
+        self._header = app.config.get('REQUEST_ID_HEADER_NAME')
+        # Set wsgi
+        self.app = app.wsgi_app
+        app.wsgi_app = self
 
     def __call__(self, environ, start_response):
         # Reading request headers


### PR DESCRIPTION
- **Added support for [app factory pattern](https://flask.palletsprojects.com/en/2.3.x/patterns/appfactories/)**
- Updated README to point to correct PyPi package name `request-id-flask` instead of the Chinese module this appears to be based on
- Updated README to reference support for app factory pattern
- Updated README to include example of `requirements.txt` and its usage
- Updated `setup.py` supported Python versions list to show specific version support on PyPi package page. I'm using this module on Python 3.12, so I added support for versions 3.6 - 3.12.
- Bumped module version to `0.0.3` in `setup.py`